### PR TITLE
remove isDevelopingAddon

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-bootstrap-changeset-validations',
-  isDevelopingAddon: function() {
-    return true;
-  }
+  name: 'ember-bootstrap-changeset-validations'
 };


### PR DESCRIPTION
If `isDevelopingAddon` is set to `true` application linting rules are run against this addon. I'm using ember-suave and therefore seeing some issues. This was discussed [here](https://github.com/DockYard/ember-suave/issues/138) for another addon.