### PR TITLE
hide deprecation notice when subclassing ember bootstrap classes

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -4,6 +4,7 @@ import RSVP from 'rsvp';
 import BsForm from 'ember-bootstrap/components/bs-form';
 
 export default BsForm.extend({
+  '__ember-bootstrap_subclass' : true,
 
   hasValidator: notEmpty('model.validate'),
 

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -4,6 +4,8 @@ import { A } from '@ember/array';
 import BsFormElement from 'ember-bootstrap/components/bs-form/element';
 
 export default BsFormElement.extend({
+  '__ember-bootstrap_subclass' : true,
+
   hasValidator: notEmpty('model.validate'),
 
   setupValidations() {


### PR DESCRIPTION
fixes #24 

should this also be done for https://github.com/kaliber5/ember-bootstrap-changeset-validations/blob/master/addon/components/bs-form/element.js