### PR TITLE
Convert extended Form to native class, providing compatibility with ember-bootstrap 5.1+

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -1,24 +1,24 @@
-import { notEmpty } from '@ember/object/computed';
 import { assert } from '@ember/debug';
-import RSVP from 'rsvp';
 import BsForm from 'ember-bootstrap/components/bs-form';
 
-export default BsForm.extend({
-  '__ember-bootstrap_subclass': true,
+export default class BsFormWithChangesetValidationsSupport extends BsForm {
+  '__ember-bootstrap_subclass' = true;
 
-  hasValidator: notEmpty('model.validate'),
+  get hasValidator() {
+    return typeof this.model?.validate === 'function';
+  }
 
-  validate(model) {
+  async validate(model) {
     let m = model;
 
     assert(
       'Model must be a Changeset instance',
       m && typeof m.validate === 'function'
     );
-    return new RSVP.Promise(function (resolve, reject) {
-      m.validate().then(() => {
-        model.get('isValid') ? resolve() : reject();
-      }, reject);
-    });
-  },
-});
+
+    await m.validate();
+    if (!model.get('isValid')) {
+      throw new Error();
+    }
+  }
+}


### PR DESCRIPTION
This should unblock https://github.com/kaliber5/ember-bootstrap/pull/1775 (took me way to long to get back to this...)

Tested locally with `yalc` and that branch of ember-bootstrap.